### PR TITLE
refactor: migrate to Spring Boot 3 (Jakarta JPA), enhance services/co…

### DIFF
--- a/src/main/java/com/wayne/golfclubapi/controller/MemberController.java
+++ b/src/main/java/com/wayne/golfclubapi/controller/MemberController.java
@@ -1,7 +1,7 @@
 package com.wayne.golfclubapi.controller;
 
-import com.yourorg.golfclubapi.entity.Member;
-import com.yourorg.golfclubapi.service.MemberService;
+import com.wayne.golfclubapi.entity.Member;
+import com.wayne.golfclubapi.service.MemberService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,31 +21,39 @@ public class MemberController {
         this.service = service;
     }
 
-    // GET /api/members
     @GetMapping
     public ResponseEntity<List<Member>> listAll() {
-        return ResponseEntity.ok(service.getAll());
+        return ResponseEntity.ok(service.getAllMembers());
     }
 
-    // GET /api/members/{id}
     @GetMapping("/{id}")
     public ResponseEntity<Member> getOne(@PathVariable Long id) {
-        return service.getById(id)
+        return service.getMemberById(id)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    // POST /api/members
     @PostMapping
     public ResponseEntity<Member> create(@RequestBody Member m) {
-        Member saved = service.save(m);
+        Member saved = service.createMember(m);
         return new ResponseEntity<>(saved, HttpStatus.CREATED);
     }
 
-    // DELETE /api/members/{id}
+    @PutMapping("/{id}")
+    public ResponseEntity<Member> update(
+            @PathVariable Long id,
+            @RequestBody Member m
+    ) {
+        return service.updateMember(id, m)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
-        service.delete(id);
-        return ResponseEntity.noContent().build();
+        boolean deleted = service.deleteMember(id);
+        return deleted
+                ? ResponseEntity.noContent().build()
+                : ResponseEntity.notFound().build();
     }
 }

--- a/src/main/java/com/wayne/golfclubapi/controller/ScoreController.java
+++ b/src/main/java/com/wayne/golfclubapi/controller/ScoreController.java
@@ -1,4 +1,3 @@
-// src/main/java/com/yourorg/golfclubapi/controller/ScoreController.java
 package com.wayne.golfclubapi.controller;
 
 import com.wayne.golfclubapi.entity.Score;
@@ -21,8 +20,9 @@ public class ScoreController {
     }
 
     @GetMapping
-    public List<Score> getAllScores() {
-        return scoreService.getAllScores();
+    public ResponseEntity<List<Score>> getAllScores() {
+        List<Score> list = scoreService.getAllScores();
+        return ResponseEntity.ok(list);
     }
 
     @GetMapping("/{id}")
@@ -33,8 +33,9 @@ public class ScoreController {
     }
 
     @PostMapping
-    public Score createScore(@RequestBody Score score) {
-        return scoreService.createScore(score);
+    public ResponseEntity<Score> createScore(@RequestBody Score score) {
+        Score saved = scoreService.createScore(score);
+        return new ResponseEntity<>(saved, HttpStatus.CREATED);
     }
 
     @PutMapping("/{id}")
@@ -54,4 +55,15 @@ public class ScoreController {
                 ? ResponseEntity.noContent().build()
                 : ResponseEntity.notFound().build();
     }
+
+    @GetMapping(params = "tournamentId")
+    public ResponseEntity<List<Score>> byTournament(@RequestParam Long tournamentId) {
+        return ResponseEntity.ok(scoreService.getByTournamentId(tournamentId));
+    }
+
+    @GetMapping(params = "memberId")
+    public ResponseEntity<List<Score>> byMember(@RequestParam Long memberId) {
+        return ResponseEntity.ok(scoreService.getByMemberId(memberId));
+    }
+
 }

--- a/src/main/java/com/wayne/golfclubapi/controller/TournamentController.java
+++ b/src/main/java/com/wayne/golfclubapi/controller/TournamentController.java
@@ -4,6 +4,7 @@ package com.wayne.golfclubapi.controller;
 import com.wayne.golfclubapi.entity.Tournament;
 import com.wayne.golfclubapi.service.TournamentService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,10 +22,10 @@ public class TournamentController {
     }
 
     @GetMapping
-    public List<Tournament> getAllTournaments() {
-        return tournamentService.getAllTournaments();
+    public ResponseEntity<List<Tournament>> getAllTournaments() {
+        List<Tournament> list = tournamentService.getAllTournaments();
+        return ResponseEntity.ok(list);
     }
-
     @GetMapping("/{id}")
     public ResponseEntity<Tournament> getTournamentById(@PathVariable Long id) {
         return tournamentService.getTournamentById(id)
@@ -33,8 +34,11 @@ public class TournamentController {
     }
 
     @PostMapping
-    public Tournament createTournament(@RequestBody Tournament tournament) {
-        return tournamentService.createTournament(tournament);
+    public ResponseEntity<Tournament> createTournament(
+            @RequestBody Tournament t
+    ) {
+        Tournament saved = tournamentService.createTournament(t);
+        return new ResponseEntity<>(saved, HttpStatus.CREATED);
     }
 
     @PutMapping("/{id}")
@@ -74,4 +78,14 @@ public class TournamentController {
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
+    // GET /api/tournaments?memberId=5
+    @GetMapping(params = "memberId")
+    public ResponseEntity<List<Tournament>> byMember(
+            @RequestParam Long memberId
+    ) {
+        return ResponseEntity.ok(
+                tournamentService.findByParticipant(memberId)
+        );
+    }
+
 }

--- a/src/main/java/com/wayne/golfclubapi/entity/Member.java
+++ b/src/main/java/com/wayne/golfclubapi/entity/Member.java
@@ -1,6 +1,6 @@
 package com.wayne.golfclubapi.entity;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.time.LocalDate;
 
 /**

--- a/src/main/java/com/wayne/golfclubapi/entity/Score.java
+++ b/src/main/java/com/wayne/golfclubapi/entity/Score.java
@@ -1,6 +1,7 @@
 package com.wayne.golfclubapi.entity;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
 
 @Entity

--- a/src/main/java/com/wayne/golfclubapi/entity/Tournament.java
+++ b/src/main/java/com/wayne/golfclubapi/entity/Tournament.java
@@ -1,6 +1,6 @@
 package com.wayne.golfclubapi.entity;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.HashSet;

--- a/src/main/java/com/wayne/golfclubapi/repository/MemberRepository.java
+++ b/src/main/java/com/wayne/golfclubapi/repository/MemberRepository.java
@@ -1,13 +1,10 @@
-// src/main/java/com/yourorg/golfclubapi/repository/MemberRepository.java
 package com.wayne.golfclubapi.repository;
 
 import com.wayne.golfclubapi.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
-import java.util.Optional;
 
 public interface MemberRepository
         extends JpaRepository<Member, Long>, JpaSpecificationExecutor<Member> {
 
-    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/wayne/golfclubapi/service/MemberService.java
+++ b/src/main/java/com/wayne/golfclubapi/service/MemberService.java
@@ -35,7 +35,10 @@ public class MemberService {
                 .map(existing -> {
                     existing.setName(details.getName());
                     existing.setEmail(details.getEmail());
-                    existing.setMembershipStartDate(details.getMembershipStartDate());
+                    existing.setAddress(details.getAddress());
+                    existing.setPhone(details.getPhone());
+                    existing.setStartDate(details.getStartDate());
+                    existing.setDurationMonths(details.getDurationMonths());
                     return memberRepository.save(existing);
                 });
     }

--- a/src/main/java/com/wayne/golfclubapi/service/ScoreService.java
+++ b/src/main/java/com/wayne/golfclubapi/service/ScoreService.java
@@ -1,9 +1,15 @@
 package com.wayne.golfclubapi.service;
 
 import com.wayne.golfclubapi.entity.Score;
+import com.wayne.golfclubapi.entity.Member;
+import com.wayne.golfclubapi.entity.Tournament;
 import com.wayne.golfclubapi.repository.ScoreRepository;
+import com.wayne.golfclubapi.repository.MemberRepository;
+import com.wayne.golfclubapi.repository.TournamentRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,10 +18,18 @@ import java.util.Optional;
 public class ScoreService {
 
     private final ScoreRepository scoreRepository;
+    private final MemberRepository memberRepository;
+    private final TournamentRepository tournamentRepository;
 
     @Autowired
-    public ScoreService(ScoreRepository scoreRepository) {
-        this.scoreRepository = scoreRepository;
+    public ScoreService(
+            ScoreRepository scoreRepository,
+            MemberRepository memberRepository,
+            TournamentRepository tournamentRepository
+    ) {
+        this.scoreRepository      = scoreRepository;
+        this.memberRepository     = memberRepository;
+        this.tournamentRepository = tournamentRepository;
     }
 
     public List<Score> getAllScores() {
@@ -27,14 +41,45 @@ public class ScoreService {
     }
 
     public Score createScore(Score score) {
+        // Validate member exists
+        Member member = memberRepository.findById(score.getMember().getId())
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST,
+                        "Invalid member ID: " + score.getMember().getId()
+                ));
+
+        // Validate tournament exists
+        Tournament tournament = tournamentRepository.findById(score.getTournament().getId())
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST,
+                        "Invalid tournament ID: " + score.getTournament().getId()
+                ));
+
+        // Attach managed entities and save
+        score.setMember(member);
+        score.setTournament(tournament);
         return scoreRepository.save(score);
     }
 
     public Optional<Score> updateScore(Long id, Score details) {
         return scoreRepository.findById(id)
                 .map(existing -> {
-                    existing.setTournament(details.getTournament());
-                    existing.setMember(details.getMember());
+                    // Validate member on update
+                    Member member = memberRepository.findById(details.getMember().getId())
+                            .orElseThrow(() -> new ResponseStatusException(
+                                    HttpStatus.BAD_REQUEST,
+                                    "Invalid member ID: " + details.getMember().getId()
+                            ));
+
+                    // Validate tournament on update
+                    Tournament tournament = tournamentRepository.findById(details.getTournament().getId())
+                            .orElseThrow(() -> new ResponseStatusException(
+                                    HttpStatus.BAD_REQUEST,
+                                    "Invalid tournament ID: " + details.getTournament().getId()
+                            ));
+
+                    existing.setMember(member);
+                    existing.setTournament(tournament);
                     existing.setStrokes(details.getStrokes());
                     existing.setRecordedAt(details.getRecordedAt());
                     return scoreRepository.save(existing);
@@ -48,5 +93,13 @@ public class ScoreService {
                     return true;
                 })
                 .orElse(false);
+    }
+
+    public List<Score> getByTournamentId(Long tournamentId) {
+        return scoreRepository.findByTournamentId(tournamentId);
+    }
+
+    public List<Score> getByMemberId(Long memberId) {
+        return scoreRepository.findByMemberId(memberId);
     }
 }

--- a/src/main/java/com/wayne/golfclubapi/service/TournamentService.java
+++ b/src/main/java/com/wayne/golfclubapi/service/TournamentService.java
@@ -1,4 +1,3 @@
-// src/main/java/com/yourorg/golfclubapi/service/TournamentService.java
 package com.wayne.golfclubapi.service;
 
 import com.wayne.golfclubapi.entity.Member;
@@ -80,4 +79,14 @@ public class TournamentService {
         }
         return Optional.empty();
     }
+
+    public List<Tournament> findByParticipant(Long memberId) {
+        return tournamentRepository.findAll((root, q, cb) ->
+                cb.isMember(
+                        memberRepository.getOne(memberId),
+                        root.get("participants")
+                )
+        );
+    }
+
 }


### PR DESCRIPTION
 Switched all JPA imports to the Jakarta API (Spring Boot 3) 
 Verified field mappings on Member, Tournament, and Score 
 Service layer  - validate referenced IDs on create/update, and throw 400 Bad Request when they don’t exist. 
 Controller layer • Unified every endpoint to return ResponseEntity
 Aligned controller method calls to the renamed service methods (getMemberById, createMember, deleteMember)
 Added the missing PUT /api/members/{id} and score-filtering endpoints